### PR TITLE
Update passport to get version of tokenPassport from client version

### DIFF
--- a/netsuite/client.py
+++ b/netsuite/client.py
@@ -155,7 +155,11 @@ class NetSuite:
         )
 
     def generate_passport(self) -> Dict[str, zeep.xsd.Element]:
-        return passport.make(self.client, self.config)
+        return passport.make(
+            self.client,
+            self.underscored_version_no_micro,
+            self.config
+        )
 
     @staticmethod
     def _set_default_soapheaders(


### PR DESCRIPTION
Currently the tokenPassport only works if you want to use v2017.2 of the API, this allows you to use the version specified on the client