### PR TITLE
0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
-sudo: false
+sudo: required
+dist: xenial
 language: python
 cache: pip
 
 matrix:
   include:
-    - python: 3.6
+    - python: "3.6"
       env: TOX_ENV=py36
-    - python: 3.7
+    - python: "3.7"
       env: TOX_ENV=py37
-    - python: 3.6
+    - python: "3.6"
       env: TOX_ENV=lint
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
   include:
     - python: 3.6
       env: TOX_ENV=py36
+    - python: 3.7
+      env: TOX_ENV=py37
     - python: 3.6
       env: TOX_ENV=lint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.0 (2018-12-11)
+
+* Breaking change: Sandbox is now configured through account ID, `sandbox` flag is now a no-op
+* Breaking change: New default version is 2018.1.0
+* Breaking change: Account specific domains are now used when `wsdl_url` is left unspecified
+* Feature: Support regular credentials Passport
+* Info: Listing Python 3.7 as a supported version
+
 ## 0.1.1 (2018-04-02)
 
 * Fix: `getItemAvailability` only read first passed in external/internal ID

--- a/README.md
+++ b/README.md
@@ -18,8 +18,3 @@ Programmatic use only:
 With CLI support:
 
     pip install netsuite[cli]
-
-
-## Notes
-
-Please note that only token based authentication is supported currently (which is preferable because we can avoid password changes etc).

--- a/netsuite/__main__.py
+++ b/netsuite/__main__.py
@@ -18,19 +18,21 @@ def _set_log_level(log_level):
         netsuite.logger.setLevel(level)
 
 
-@argh.arg('-c', '--config-section')
+@argh.arg('-l', '--log-level', help='The log level to use')
+@argh.arg('-p', '--config-path', help='The config file to get settings from')
+@argh.arg('-c', '--config-section', help='The config section to get settings from')
 @argh.arg('-p', '--config-path')
 def interact(
-    log_level: 'The log level to use' = None,
-    config_path: 'The config file to get settings from.' = DEFAULT_INI_PATH,
-    config_section: 'The config section to get settings from.' = DEFAULT_INI_SECTION,
+    log_level=None,
+    config_path=DEFAULT_INI_PATH,
+    config_section=DEFAULT_INI_SECTION,
 ):
     """Starts a REPL to enable live interaction with NetSuite webservices"""
     _set_log_level(log_level)
 
     conf = config.from_ini(path=config_path, section=config_section)
-    ns = netsuite.NetSuite(conf, sandbox=True)
-    # print(ns.getList('customer', internalIds=['11397']))
+
+    ns = netsuite.NetSuite(conf)
 
     user_ns = {'ns': ns}
 

--- a/netsuite/config.py
+++ b/netsuite/config.py
@@ -1,5 +1,5 @@
 import configparser
-from typing import Any, Dict, Tuple
+from typing import Dict
 
 from .constants import DEFAULT_INI_PATH, DEFAULT_INI_SECTION, NOT_SET
 
@@ -47,13 +47,7 @@ class Config:
     preferences = None
     """Additional preferences"""
 
-    _settings_mapping: Tuple[
-        Tuple[
-            str,
-            Dict[str, Any]
-        ],
-        ...
-    ] = (
+    _settings_mapping = (
         (
             'account',
             {'type': str, 'required': True},

--- a/netsuite/config.py
+++ b/netsuite/config.py
@@ -3,6 +3,9 @@ from typing import Any, Dict, Tuple
 
 from .constants import DEFAULT_INI_PATH, DEFAULT_INI_SECTION, NOT_SET
 
+TOKEN = 'token'
+CREDENTIALS = 'credentials'
+
 
 class Config:
     """
@@ -13,6 +16,9 @@ class Config:
         **opts:
             Dictionary keys/values that will be set as attribute names/values
     """
+
+    auth_type = TOKEN
+    """The authentication type to use, either 'token' or 'credentials'"""
 
     account = None
     """The NetSuite account ID"""
@@ -28,6 +34,15 @@ class Config:
 
     token_secret = None
     """The OAuth 1.0 token secret"""
+
+    application_id = None
+    """Application ID, used with auth_type=credentials"""
+
+    email = None
+    """Account e-mail, used with auth_type=credentials"""
+
+    password = None
+    """Account password, used with auth_type=credentials"""
 
     preferences = None
     """Additional preferences"""
@@ -45,19 +60,31 @@ class Config:
         ),
         (
             'consumer_key',
-            {'type': str, 'required': True},
+            {'type': str, 'required_for_auth_type': TOKEN},
         ),
         (
             'consumer_secret',
-            {'type': str, 'required': True},
+            {'type': str, 'required_for_auth_type': TOKEN},
         ),
         (
             'token_id',
-            {'type': str, 'required': True},
+            {'type': str, 'required_for_auth_type': TOKEN},
         ),
         (
             'token_secret',
-            {'type': str, 'required': True},
+            {'type': str, 'required_for_auth_type': TOKEN},
+        ),
+        (
+            'application_id',
+            {'type': str, 'required_for_auth_type': CREDENTIALS},
+        ),
+        (
+            'email',
+            {'type': str, 'required_for_auth_type': CREDENTIALS},
+        ),
+        (
+            'password',
+            {'type': str, 'required_for_auth_type': CREDENTIALS},
         ),
         (
             'preferences',
@@ -71,12 +98,26 @@ class Config:
     def __contains__(self, key: str) -> bool:
         return hasattr(self, key)
 
+    def _set_auth_type(self, value: str) -> None:
+        self._validate_attr('auth_type', value, str, True, {})
+        self.auth_type = value
+        assert self.auth_type in (TOKEN, CREDENTIALS)
+
     def _set(self, dct: Dict[str, object]) -> None:
+        # As other setting validations depend on auth_type we set it first
+        auth_type = dct.get('auth_type', self.auth_type)
+        self._set_auth_type(auth_type)
+
         for attr, opts in self._settings_mapping:
             value = dct.get(attr, NOT_SET)
             type_ = opts['type']
-            required = opts['required']
-            self._validate_attr(attr, value, type_, required)
+
+            required = opts.get(
+                'required',
+                opts.get('required_for_auth_type') == auth_type
+            )
+
+            self._validate_attr(attr, value, type_, required, opts)
 
             if value is NOT_SET and 'default' in opts:
                 value = opts['default']()
@@ -89,9 +130,17 @@ class Config:
         value: object,
         type_: object,
         required: bool,
+        opts: dict
     ) -> None:
         if required and value is NOT_SET:
-            raise ValueError(f'Attribute {attr} is required')
+            required_for_auth_type = opts.get('required_for_auth_type')
+            if required_for_auth_type:
+                raise ValueError(
+                    f'Attribute {attr} is required for auth_type='
+                    f'`{required_for_auth_type}`'
+                )
+            else:
+                raise ValueError(f'Attribute {attr} is required')
         if value is not NOT_SET and not isinstance(value, type_):
             raise ValueError(f'Attribute {attr} is not of type `{type_}`')
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup_kwargs = dict(
     name='netsuite',
-    version='0.1.1',
+    version='0.2.0',
     description='Wrapper around Netsuite SuiteTalk Web Services',
     packages=['netsuite'],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup_kwargs = dict(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -15,9 +15,9 @@ def dummy_config():
 
 def test_netsuite_hostname(dummy_config):
     ns = netsuite.NetSuite(dummy_config)
-    assert ns.hostname == 'webservices.sandbox.netsuite.com'
+    assert ns.hostname == '123456.suitetalk.api.netsuite.com'
 
 
 def test_netsuite_wsdl_url(dummy_config):
     ns = netsuite.NetSuite(dummy_config)
-    assert ns.wsdl_url == 'https://webservices.sandbox.netsuite.com/wsdl/v2017_2_0/netsuite.wsdl'
+    assert ns.wsdl_url == 'https://123456.suitetalk.api.netsuite.com/wsdl/v2018_1_0/netsuite.wsdl'

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, lint
+envlist = py36, py37, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
* Breaking change: Sandbox is now configured through account ID, `sandbox` flag is now a no-op
* Breaking change: New default version is 2018.1.0
* Breaking change: Account specific domains are now used when `wsdl_url` is left unspecified
* Feature: Support regular credentials Passport
* Info: Listing Python 3.7 as a supported version