### PR TITLE
v0.5.0 - Support for NetSuite SuiteTalk Web Services REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.0 (2020-05-02)
+
+* Feature: Support for SuiteTalk REST Web Services, including standard GET, POST, PATCH, PUT, DELETE requests as well as making SuiteQL queries. For now it's an optional dependency (install with `pip install netsuite[rest_api]`)
+* Feature: Start a HTTP server via command line to browse REST API OpenAPI spec docs for a given set of records (utilizes Swagger UI)
+* Breaking change: `--log-level`, `--config-path` and `--config-section` must now be passed directly to the `netsuite` command, and not its sub-commands.
+
 ## 0.4.1 (2020-03-09)
 
 * Extend Zeep Transport GET and POST HTTP methods to apply the account-specific dynamic domain as the remote host

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/netsuite.svg)](https://pypi.python.org/pypi/netsuite/)
 [![PyPI status (alpha/beta/stable)](https://img.shields.io/pypi/status/netsuite.svg)](https://pypi.python.org/pypi/netsuite/)
 
-Make requests to NetSuite Web Services and Restlets
+Make requests to NetSuite SuiteTalk SOAP/REST Web Services and Restlets
 
 ## Installation
 
@@ -18,6 +18,14 @@ Programmatic use only:
 With CLI support:
 
     pip install netsuite[cli]
+
+With NetSuite SuiteTalk REST Web Services API support:
+
+    pip install netsuite[rest_api]
+
+With all features:
+
+    pip install netsuite[all]
 
 
 ## CLI
@@ -42,14 +50,104 @@ The default location that will be read is `~/.config/netsuite.ini`. This can ove
 
 Append `--help` to the commands to see full documentation.
 
-### `restlet` - Make requests to restlets
+### `rest-api` - Make requests to NetSuite REST API
+
+See the NetSuite help center for info on how to use the REST API. The `netsuite rest-api openapi-serve` command is also a big help.
+
+#### `netsuite rest-api get`
+
+List endpoint examples:
 
 ```
-$ echo '{"savedSearchId": 987}' | netsuite restlet 123 -
+$ netsuite rest-api get /record/v1/customer
+```
+
+```
+$ netsuite rest-api get /record/v1/invoice --limit 10 --offset 30
+```
+
+```
+$ netsuite rest-api get /record/v1/salesOrder --query 'email IS "john.doe@example.com"'
+```
+
+Detail endpoint examples:
+
+```
+$ netsuite rest-api get /record/v1/salesOrder/1337
+```
+
+```
+$ netsuite rest-api get /record/v1/invoice/123 --expandSubResources
+```
+
+#### `netsuite rest-api post`
+
+Examples:
+```
+$ cat ~/customer-no-1-data.json | netsuite rest-api post /record/v1/customer -
+```
+
+#### `netsuite rest-api put`
+
+Examples:
+```
+$ cat ~/customer-no-1-data.json | netsuite rest-api put /record/v1/customer/123 -
+```
+
+#### `netsuite rest-api patch`
+
+Examples:
+```
+$ cat ~/changed-customer-data.json | netsuite rest-api patch /record/v1/customer/123 -
+```
+
+#### `netsuite rest-api delete`
+
+Examples:
+```
+$ netsuite rest-api delete /record/v1/customer/123
+```
+
+#### `netsuite rest-api jsonschema`
+
+Examples:
+```
+$ netsuite rest-api jsonschema salesOrder
+{"type":"object","properties":...
+```
+
+#### `netsuite rest-api openapi`
+
+Examples:
+```
+$ netsuite rest-api openapi salesOrder customer invoice
+{"openapi":"3.0.1","info":{"title":"NetSuite REST Record API"...
 ```
 
 
-### `interact` - Interact with web services and/or restlets
+#### `netsuite rest-api openapi-serve`
+
+Start a server that fetches and lists the OpenAPI spec for the given record types, using [Swagger UI](https://swagger.io/tools/swagger-ui/). Defaults to port 8000.
+
+Examples:
+
+```
+$ netsuite rest-api openapi-serve customer salesOrder
+INFO:netsuite:Fetching OpenAPI spec for record types customer, salesOrder...
+INFO:netsuite:NetSuite REST API docs available at http://127.0.0.1:8001
+```
+
+It's also possible to fetch the OpenAPI spec for all known record types. This will however take a long time (60+ seconds).
+```
+$ netsuite rest-api openapi-serve
+WARNING:netsuite:Fetching OpenAPI spec for ALL known record types... This will take a long time! (Consider providing only the record types of interest by passing their names to this command as positional arguments)
+INFO:netsuite:NetSuite REST API docs available at http://127.0.0.1:8001
+```
+
+
+### `interact` - Interact with SOAP/REST web services and restlets
+
+Starts an IPython REPL where you can interact with the client.
 
 ```
 $ netsuite interact
@@ -58,7 +156,16 @@ Available vars:
     `ns` - NetSuite client
 
 Example usage:
-    results = ns.getList('customer', internalIds=[1337])
+    ws_results = ns.getList('customer', internalIds=[1337])
+    restlet_results = ns.restlet.request(987)
+    rest_api_results = await ns.rest_api.get("/record/v1/salesOrder")
 
-In [1]:
+In [1]: rest_api_results = await ns.rest_api.get("
+```
+
+
+### `restlet` - Make requests to restlets
+
+```
+$ echo '{"savedSearchId": 987}' | netsuite restlet 123 -
 ```

--- a/netsuite/__main__.py
+++ b/netsuite/__main__.py
@@ -1,41 +1,60 @@
-import json
-import sys
+import argparse
+import asyncio
+import functools
+import http.server
+import inspect
 import logging
 import logging.config
+import pathlib
+import pkg_resources
+import sys
+import tempfile
 
 import IPython
-import argh
 import traitlets
 
 import netsuite
-from netsuite import config
+from netsuite import config, json
 from netsuite.constants import DEFAULT_INI_PATH, DEFAULT_INI_SECTION
 
-
-def _set_log_level(log_level):
-    if log_level is not None:
-        level = getattr(logging, log_level.upper())
-        logging.basicConfig()
-        logging.getLogger('zeep').setLevel(level)
-        netsuite.logger.setLevel(level)
+logger = logging.getLogger("netsuite")
 
 
-@argh.arg('-l', '--log-level', help='The log level to use')
-@argh.arg('-p', '--config-path', help='The config file to get settings from')
-@argh.arg('-c', '--config-section', help='The config section to get settings from')
-def interact(
-    log_level=None,
-    config_path=DEFAULT_INI_PATH,
-    config_section=DEFAULT_INI_SECTION
-):
-    """Starts a REPL to enable live interaction with NetSuite webservices"""
-    _set_log_level(log_level)
+def main():
+    try:
+        args = parser.parse_args()
+    except Exception:
+        parser.print_help()
+        return
 
-    conf = config.from_ini(path=config_path, section=config_section)
+    subparser_name = sys.argv[-1]
 
-    ns = netsuite.NetSuite(conf)
+    if subparser_name == "rest-api":
+        rest_api_parser.print_help()
+        return
 
-    user_ns = {'ns': ns}
+    config = _load_config_or_error(args.config_path, args.config_section)
+
+    log_level = getattr(logging, args.log_level)
+    logging.basicConfig(level=log_level)
+
+    ret = args.func(config, args)
+
+    if inspect.iscoroutinefunction(args.func):
+        ret = asyncio.run(ret)
+
+    if ret is not None:
+        print(ret)
+
+
+def version(config, args) -> str:
+    return pkg_resources.get_distribution("netsuite").version
+
+
+def interact(config, args):
+    ns = netsuite.NetSuite(config)
+
+    user_ns = {"ns": ns}
 
     banner1 = """Welcome to Netsuite WS client interactive mode
 Available vars:
@@ -44,12 +63,13 @@ Available vars:
 Example usage:
     ws_results = ns.getList('customer', internalIds=[1337])
     restlet_results = ns.restlet.request(987)
+    rest_api_results = await ns.rest_api.get("/record/v1/salesOrder")
 """
 
     IPython.embed(
         user_ns=user_ns,
         banner1=banner1,
-        config=traitlets.config.Config(colors='LightBG'),
+        config=traitlets.config.Config(colors="LightBG"),
         # To fix no colored input we pass in `using=False`
         # See: https://github.com/ipython/ipython/issues/11523
         # TODO: Remove once this is fixed upstream
@@ -57,39 +77,334 @@ Example usage:
     )
 
 
-@argh.arg('-l', '--log-level', help='The log level to use')
-@argh.arg('-p', '--config-path', help='The config file to get settings from')
-@argh.arg('-c', '--config-section', help='The config section to get settings from')
-def restlet(
-    script_id,
-    payload,
-    deploy=1,
-    log_level=None,
-    config_path=DEFAULT_INI_PATH,
-    config_section=DEFAULT_INI_SECTION
-):
-    """Make requests to restlets"""
+def restlet(config, args) -> str:
+    ns = netsuite.NetSuite(config)
 
-    _set_log_level(log_level)
-    conf = config.from_ini(path=config_path, section=config_section)
-    ns = netsuite.NetSuite(conf)
-
-    if not payload:
+    if not args.payload:
         payload = None
-    elif payload == '-':
-        payload = json.load(sys.stdin)
+    elif args.payload == "-":
+        with sys.stdin as fh:
+            payload = json.loads(fh.read())
     else:
-        payload = json.loads(payload)
+        payload = json.loads(args.payload)
 
     resp = ns.restlet.raw_request(
-        script_id=script_id,
-        deploy=deploy,
+        script_id=args.script_id,
+        deploy=args.deploy,
         payload=payload,
         raise_on_bad_status=False,
     )
     return resp.text
 
 
-command_parser = argh.ArghParser()
-command_parser.add_commands([interact, restlet])
-main = command_parser.dispatch
+async def rest_api_get(config, args) -> str:
+    rest_api = _get_rest_api_or_error(config)
+    params = {}
+    if args.expandSubResources:
+        params["expandSubResources"] = "true"
+    if args.limit:
+        params["limit"] = args.limit
+    if args.offset:
+        params["offset"] = args.offset
+    if args.query:
+        params["q"] = args.query
+    resp = await rest_api.get(args.subpath, params=params)
+    return json.dumps_str(resp)
+
+
+async def rest_api_post(config, args) -> str:
+    rest_api = _get_rest_api_or_error(config)
+    with args.payload_file as fh:
+        payload_str = fh.read()
+
+    payload = json.loads(payload_str)
+
+    resp = await rest_api.post(args.subpath, json=payload)
+    return json.dumps_str(resp)
+
+
+async def rest_api_put(config, args) -> str:
+    rest_api = _get_rest_api_or_error(config)
+    with args.payload_file as fh:
+        payload_str = fh.read()
+
+    payload = json.loads(payload_str)
+
+    resp = await rest_api.put(args.subpath, json=payload)
+    return json.dumps_str(resp)
+
+
+async def rest_api_patch(config, args) -> str:
+    rest_api = _get_rest_api_or_error(config)
+    with args.payload_file as fh:
+        payload_str = fh.read()
+
+    payload = json.loads(payload_str)
+
+    resp = await rest_api.patch(args.subpath, json=payload)
+    return json.dumps_str(resp)
+
+
+async def rest_api_delete(config, args) -> str:
+    rest_api = _get_rest_api_or_error(config)
+
+    resp = await rest_api.delete(args.subpath)
+    return json.dumps_str(resp)
+
+
+async def rest_api_suiteql(config, args) -> str:
+    rest_api = _get_rest_api_or_error(config)
+
+    with args.q_file as fh:
+        q = fh.read()
+
+    resp = await rest_api.suiteql(q=q, limit=args.limit, offset=args.offset)
+
+    return json.dumps_str(resp)
+
+
+async def rest_api_jsonschema(config, args) -> str:
+    rest_api = _get_rest_api_or_error(config)
+    resp = await rest_api.jsonschema(args.record_type)
+    return json.dumps_str(resp)
+
+
+async def rest_api_openapi(config, args) -> str:
+    rest_api = _get_rest_api_or_error(config)
+    resp = await rest_api.openapi(args.record_types)
+    return json.dumps_str(resp)
+
+
+async def rest_api_openapi_serve(config, args) -> str:
+    rest_api = _get_rest_api_or_error(config)
+    if len(args.record_types) == 0:
+        logger.warning(
+            "Fetching OpenAPI spec for ALL known record types... This will take a long "
+            "time! (Consider providing only the record types of interest by passing "
+            "their names to this command as positional arguments)"
+        )
+    else:
+        rt_str = ", ".join(args.record_types)
+        logger.info(f"Fetching OpenAPI spec for record types {rt_str}...")
+    spec = await rest_api.openapi(args.record_types)
+    tempdir = pathlib.Path(tempfile.mkdtemp())
+    openapi_file = tempdir / "openapi.json"
+    html_file = tempdir / "index.html"
+    openapi_file.write_bytes(json.dumps(spec))
+    html = """<!DOCTYPE html>
+<html>
+    <head>
+    <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css">
+    <title>OpenAPI for </title>
+    </head>
+    <body>
+    <div id="swagger-ui">
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+    <!-- `SwaggerUIBundle` is now available on the page -->
+    <script>
+    const ui = SwaggerUIBundle({
+        url: '/openapi.json',
+        dom_id: '#swagger-ui',
+        presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIBundle.SwaggerUIStandalonePreset
+        ],
+        layout: "BaseLayout",
+        deepLinking: true
+    })
+    </script>
+    </body>
+</html>"""
+    html_file.write_text(html)
+    handler_class = functools.partial(
+        http.server.SimpleHTTPRequestHandler, directory=str(tempdir),
+    )
+    logger.info(
+        f"NetSuite REST Record API docs available at http://{args.bind}:{args.port}"
+    )
+    try:
+        http.server.test(
+            HandlerClass=handler_class,
+            ServerClass=http.server.ThreadingHTTPServer,
+            port=args.port,
+            bind=args.bind,
+        )
+    finally:
+        html_file.unlink()
+        openapi_file.unlink()
+        tempdir.rmdir()
+
+
+def _load_config_or_error(path: str, section: str) -> config.Config:
+    try:
+        return config.from_ini(path=path, section=section)
+    except FileNotFoundError:
+        parser.error(f"Config file {path} not found")
+    except KeyError as ex:
+        if ex.args == (section,):
+            parser.error(f"No config section `{section}` in file {path}")
+        else:
+            raise ex
+
+
+def _get_rest_api_or_error(config: config.Config):
+    ns = netsuite.NetSuite(config)
+
+    try:
+        return ns.rest_api  # Cached property that initializes NetSuiteRestApi
+    except RuntimeError as ex:
+        parser.error(str(ex))
+
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument(
+    "-l",
+    "--log-level",
+    help="The log level to use",
+    default="INFO",
+    choices=("DEBUG", "INFO", "WARNING", "ERROR"),
+)
+parser.add_argument(
+    "-p",
+    "--config-path",
+    help="The config file to get settings from",
+    default=DEFAULT_INI_PATH,
+)
+parser.add_argument(
+    "-c",
+    "--config-section",
+    help="The config section to get settings from",
+    default=DEFAULT_INI_SECTION,
+)
+
+subparsers = parser.add_subparsers(help="App CLI", required=True)
+
+version_parser = subparsers.add_parser("version")
+version_parser.set_defaults(func=version)
+
+interact_parser = subparsers.add_parser(
+    "interact",
+    aliases=["i"],
+    description="Starts a REPL to enable live interaction with NetSuite webservices",
+)
+interact_parser.set_defaults(func=interact)
+
+restlet_parser = subparsers.add_parser(
+    "restlet", description="Make request to a restlet"
+)
+restlet_parser.set_defaults(func=restlet)
+restlet_parser.add_argument("script_id", type=int)
+restlet_parser.add_argument("payload")
+restlet_parser.add_argument("-d", "--deploy", type=int, default=1)
+
+rest_api_parser = subparsers.add_parser("rest-api", aliases=["r"])
+rest_api_subparser = rest_api_parser.add_subparsers()
+
+rest_api_get_parser = rest_api_subparser.add_parser(
+    "get", description="Make a GET request to NetSuite REST web services"
+)
+rest_api_get_parser.set_defaults(func=rest_api_get)
+rest_api_get_parser.add_argument(
+    "subpath", help="The subpath to GET, e.g. `/record/v1/salesOrder`",
+)
+rest_api_get_parser.add_argument(
+    "-q",
+    "--query",
+    help="Search query used to filter results. See NetSuite help center for syntax information. Only works for list endpoints e.g. /record/v1/customer",
+)
+rest_api_get_parser.add_argument(
+    "-e",
+    "--expandSubResources",
+    action="store_true",
+    help="Automatically expand all sublists, sublist lines and subrecords on this record. Only works for detail endpoints e.g. /record/v1/invoice/123.",
+)
+rest_api_get_parser.add_argument("-l", "--limit", type=int, default=1000)
+rest_api_get_parser.add_argument("-o", "--offset", type=int, default=0)
+
+rest_api_post_parser = rest_api_subparser.add_parser(
+    "post", description="Make a POST request to NetSuite REST web services"
+)
+rest_api_post_parser.set_defaults(func=rest_api_post)
+rest_api_post_parser.add_argument(
+    "subpath", help="The subpath to POST to, e.g. `/record/v1/salesOrder`",
+)
+rest_api_post_parser.add_argument("payload_file", type=argparse.FileType("r"))
+
+rest_api_put_parser = rest_api_subparser.add_parser(
+    "put", description="Make a PUT request to NetSuite REST web services"
+)
+rest_api_put_parser.set_defaults(func=rest_api_put)
+rest_api_put_parser.add_argument(
+    "subpath", help="The subpath to PUT to, e.g. `/record/v1/salesOrder/eid:abc123`",
+)
+rest_api_put_parser.add_argument("payload_file", type=argparse.FileType("r"))
+
+rest_api_patch_parser = rest_api_subparser.add_parser(
+    "patch", description="Make a PATCH request to NetSuite REST web services"
+)
+rest_api_patch_parser.set_defaults(func=rest_api_patch)
+rest_api_patch_parser.add_argument(
+    "subpath", help="The subpath to PATCH to, e.g. `/record/v1/salesOrder/eid:abc123`",
+)
+rest_api_patch_parser.add_argument("payload_file", type=argparse.FileType("r"))
+
+rest_api_delete_parser = rest_api_subparser.add_parser(
+    "delete", description="Make a delete request to NetSuite REST web services"
+)
+rest_api_delete_parser.set_defaults(func=rest_api_delete)
+rest_api_delete_parser.add_argument(
+    "subpath",
+    help="The subpath for the DELETE request, e.g. `/record/v1/salesOrder/eid:abc123`",
+)
+
+rest_api_suiteql_parser = rest_api_subparser.add_parser(
+    "suiteql", description="Make a SuiteQL request to NetSuite REST web services"
+)
+rest_api_suiteql_parser.set_defaults(func=rest_api_suiteql)
+rest_api_suiteql_parser.add_argument(
+    "q_file", type=argparse.FileType("r"), help="File containing a SuiteQL query"
+)
+rest_api_suiteql_parser.add_argument("-l", "--limit", type=int, default=10)
+rest_api_suiteql_parser.add_argument("-o", "--offset", type=int, default=0)
+
+rest_api_jsonschema_parser = rest_api_subparser.add_parser(
+    "jsonschema", description="Retrieve JSON Schema for the given record type"
+)
+rest_api_jsonschema_parser.set_defaults(func=rest_api_jsonschema)
+rest_api_jsonschema_parser.add_argument(
+    "record_type", help="The record type to get JSONSchema spec for"
+)
+
+rest_api_openapi_parser = rest_api_subparser.add_parser(
+    "openapi",
+    aliases=["oas"],
+    description="Retrieve OpenAPI spec for the given record types",
+)
+rest_api_openapi_parser.set_defaults(func=rest_api_openapi)
+rest_api_openapi_parser.add_argument(
+    "record_types",
+    metavar="record_type",
+    nargs="+",
+    help="The record type(s) to get OpenAPI spec for",
+)
+
+
+rest_api_openapi_parser = rest_api_subparser.add_parser(
+    "openapi-serve",
+    aliases=["oas-serve"],
+    description="Start a HTTP server on localhost serving the OpenAPI spec via Swagger UI",
+)
+rest_api_openapi_parser.set_defaults(func=rest_api_openapi_serve)
+rest_api_openapi_parser.add_argument(
+    "record_types",
+    metavar="record_type",
+    nargs="*",
+    help="The record type(s) to get OpenAPI spec for. If not provided the OpenAPI spec for all known record types will be retrieved.",
+)
+rest_api_openapi_parser.add_argument(
+    "-p", "--port", default=8000, type=int, help="The port to listen to"
+)
+rest_api_openapi_parser.add_argument(
+    "-b", "--bind", default="127.0.0.1", help="The host to bind to"
+)

--- a/netsuite/client.py
+++ b/netsuite/client.py
@@ -16,6 +16,7 @@ from zeep.xsd.valueobjects import CompoundValue
 from . import constants, helpers, passport
 from .config import Config
 from .restlet import NetsuiteRestlet
+from .rest_api import NetSuiteRestApi
 from .util import cached_property
 
 logger = logging.getLogger(__name__)
@@ -162,11 +163,23 @@ class NetSuite:
         self.__wsdl_url = wsdl_url
         self.__cache = cache
         self.__session = session
-        self.__restlet = NetsuiteRestlet(self.__config)
 
-    @property
+    @cached_property
     def restlet(self):
-        return self.__restlet
+        return NetsuiteRestlet(self.__config)
+
+    @cached_property
+    def rest_api(self):
+        if self.__config.is_token_auth():
+            return NetSuiteRestApi(
+                account=self.config.account,
+                consumer_key=self.config.consumer_key,
+                consumer_secret=self.config.consumer_secret,
+                token_id=self.config.token_id,
+                token_secret=self.config.token_secret,
+            )
+        else:
+            raise RuntimeError("Rest API is currently only implemented with token auth")
 
     @cached_property
     def wsdl_url(self) -> str:

--- a/netsuite/config.py
+++ b/netsuite/config.py
@@ -97,6 +97,12 @@ class Config:
         self.auth_type = value
         assert self.auth_type in (TOKEN, CREDENTIALS)
 
+    def is_token_auth(self) -> bool:
+        return self.auth_type == TOKEN
+
+    def is_credentials_auth(self) -> bool:
+        return self.auth_type == CREDENTIALS
+
     def _set(self, dct: Dict[str, object]) -> None:
         # As other setting validations depend on auth_type we set it first
         auth_type = dct.get('auth_type', self.auth_type)

--- a/netsuite/json.py
+++ b/netsuite/json.py
@@ -1,0 +1,64 @@
+import datetime
+from uuid import UUID
+from decimal import Decimal
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Dict, Type, Union
+
+import orjson as _orjson
+
+__all__ = ("dumps", "loads")
+
+loads = _orjson.loads
+
+
+def dumps(obj: Any, *args, **kw) -> bytes:
+    kw["default"] = _orjson_default
+    return _orjson.dumps(obj, *args, **kw)
+
+
+def dumps_str(obj: Any, *args, **kw) -> str:
+    return dumps(obj, *args, **kw).decode("utf-8")
+
+
+def _orjson_default(obj: Any) -> Any:
+    """Handle cases which orjson doesn't know what to do with"""
+
+    # Handle that orjson doesn't support subclasses of str
+    if isinstance(obj, str):
+        return str(obj)
+    else:
+        encoder = _get_encoder(obj)
+        return encoder(obj)
+
+
+def _isoformat(o: Union[datetime.date, datetime.time]) -> str:
+    return o.isoformat()
+
+
+def _get_encoder(obj: Any) -> Any:
+    for base in obj.__class__.__mro__[:-1]:
+        try:
+            encoder = _ENCODERS_BY_TYPE[base]
+        except KeyError:
+            continue
+        return encoder(obj)
+    else:  # We have exited the for loop without finding a suitable encoder
+        raise TypeError(
+            f"Object of type '{obj.__class__.__name__}' is not JSON serializable"
+        )
+
+
+_ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
+    bytes: lambda o: o.decode(),
+    datetime.date: _isoformat,
+    datetime.datetime: _isoformat,
+    datetime.time: _isoformat,
+    datetime.timedelta: lambda td: td.total_seconds(),
+    Decimal: float,
+    Enum: lambda o: o.value,
+    frozenset: list,
+    Path: str,
+    set: list,
+    UUID: str,
+}

--- a/netsuite/rest_api.py
+++ b/netsuite/rest_api.py
@@ -1,0 +1,198 @@
+import asyncio
+import logging
+from typing import Iterable, Optional
+
+try:
+    import httpx
+except ImportError:
+    httpx = None
+
+try:
+    from authlib.integrations.httpx_client import OAuth1Auth
+except ImportError:
+    OAuth1Auth = None
+
+from . import json
+from .types import JsonDict
+
+logger = logging.getLogger(__name__)
+
+__all__ = ("NetSuiteRestApi",)
+
+
+class NetsuiteAPIRequestError(Exception):
+    """Raised when a Netsuite REST API request fails"""
+
+    def __init__(self, status_code: int, response_text: str):
+        self.status_code = status_code
+        self.response_text = response_text
+
+    def __str__(self):
+        return f"HTTP{self.status_code} - {self.response_text}"
+
+
+class NetsuiteAPIResponseParsingError(NetsuiteAPIRequestError):
+    """Raised when parsing a Netsuite REST API response fails"""
+
+
+class NetSuiteRestApi:
+    def __init__(
+        self,
+        *,
+        account: str,
+        consumer_key: str,
+        consumer_secret: str,
+        token_id: str,
+        token_secret: str,
+        default_timeout: str = 60,
+        concurrent_requests: int = 10,
+    ):
+        if not self.has_required_dependencies():
+            raise RuntimeError(
+                "Missing required dependencies for REST API support. "
+                "Install with `pip install netsuite[rest_api]`"
+            )
+        self._account = account
+        self._hostname = self._make_hostname()
+        self._auth = self._make_auth(
+            account, consumer_key, consumer_secret, token_id, token_secret
+        )
+        self._default_timeout = default_timeout
+        self._request_semaphore = asyncio.Semaphore(concurrent_requests)
+
+    @classmethod
+    def has_required_dependencies(cls) -> bool:
+        return httpx is not None and OAuth1Auth is not None
+
+    async def get(self, subpath: str, **request_kw) -> JsonDict:
+        return await self.request("GET", subpath, **request_kw)
+
+    async def post(self, subpath: str, **request_kw):
+        return await self.request("POST", subpath, **request_kw,)
+
+    async def put(self, subpath: str, **request_kw):
+        return await self.request("PUT", subpath, **request_kw)
+
+    async def patch(self, subpath: str, **request_kw):
+        return await self.request("PATCH", subpath, **request_kw)
+
+    async def delete(self, subpath: str, **request_kw):
+        return await self.request("DELETE", subpath, **request_kw)
+
+    async def suiteql(self, q: str, limit: int = 10, offset: int = 0) -> JsonDict:
+        return await self.request(
+            "POST",
+            "/query/v1/suiteql",
+            headers={"Prefer": "transient"},
+            json={"q": q},
+            params={"limit": limit, "offset": offset},
+        )
+
+    async def jsonschema(self, record_type: str, **request_kw) -> JsonDict:
+        headers = {
+            **request_kw.pop("headers", {}),
+            "Accept": "application/schema+json",
+        }
+        return await self.request(
+            "GET",
+            f"/record/v1/metadata-catalog/{record_type}",
+            headers=headers,
+            **request_kw,
+        )
+
+    async def openapi(self, record_types: Iterable[str] = (), **request_kw) -> JsonDict:
+        headers = {
+            **request_kw.pop("headers", {}),
+            "Accept": "application/swagger+json",
+        }
+        params = request_kw.pop("params", {})
+
+        if len(record_types) > 0:
+            params["select"] = ",".join(record_types)
+
+        return await self.request(
+            "GET",
+            "/record/v1/metadata-catalog",
+            headers=headers,
+            params=params,
+            **request_kw,
+        )
+
+    async def request(
+        self, method: str, subpath: str, **request_kw
+    ) -> Optional[JsonDict]:
+        resp = await self._raw_request(method, subpath, **request_kw)
+
+        if resp.status_code < 200 or resp.status_code > 299:
+            raise NetsuiteAPIRequestError(resp.status_code, resp.text)
+
+        if resp.status_code == 204:
+            return None
+        else:
+            try:
+                return json.loads(resp.text)
+            except Exception:
+                raise NetsuiteAPIResponseParsingError(resp.status_code, resp.text)
+
+    async def _raw_request(
+        self, method: str, subpath: str, **request_kw
+    ) -> httpx.Response:
+        method = method.upper()
+        url = self._make_url(subpath)
+        headers = {**self._make_default_headers(), **request_kw.pop("headers", {})}
+
+        auth = request_kw.pop("auth", self._auth)
+        timeout = request_kw.pop("timeout", self._default_timeout)
+
+        if "json" in request_kw:
+            request_kw["data"] = json.dumps_str(request_kw.pop("json"))
+
+        kw = {**request_kw}
+        logger.debug(
+            f"Making {method.upper()} request to {url}. Keyword arguments: {kw}"
+        )
+
+        async with self._request_semaphore:
+            async with httpx.AsyncClient() as c:
+                resp = await c.request(
+                    method=method,
+                    url=url,
+                    headers=headers,
+                    auth=auth,
+                    timeout=timeout,
+                    **kw,
+                )
+
+        resp_headers_json = json.dumps_str(dict(resp.headers))
+        logger.debug(f"Got response headers from NetSuite REST API: {resp_headers_json}")
+
+        return resp
+
+    def _make_hostname(self):
+        account_slugified = self._account.lower().replace("_", "-")
+        return f"{account_slugified}.suitetalk.api.netsuite.com"
+
+    def _make_url(self, subpath: str):
+        return f"https://{self._hostname}/services/rest{subpath}"
+
+    @staticmethod
+    def _make_auth(
+        account: str,
+        consumer_key: str,
+        consumer_secret: str,
+        token_id: str,
+        token_secret: str,
+    ):
+        return OAuth1Auth(
+            client_id=consumer_key,
+            client_secret=consumer_secret,
+            token=token_id,
+            token_secret=token_secret,
+            realm=account,
+        )
+
+    def _make_default_headers(self):
+        return {
+            "Content-Type": "application/json",
+            "X-NetSuite-PropertyNameValidation": "error",
+        }

--- a/netsuite/types.py
+++ b/netsuite/types.py
@@ -1,0 +1,3 @@
+import typing
+
+JsonDict = typing.Dict[str, typing.Any]

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,31 @@
 from setuptools import setup
 
+extras_require = {
+    'rest_api': [
+        'authlib',
+        # NOTE: authlib doesn't work with httpx 0.12.1 So we're locking the httpx
+        #       version to one that is compatible. See:
+        #       https://github.com/lepture/authlib/issues/210#issuecomment-612311003
+        # TODO: Remove version lock once fixed upstream.
+        'httpx==0.12.0',
+    ],
+    'cli': ['ipython'],
+    'test': {
+        'coverage>=4.2',
+        'flake8>=3.0.4',
+        'mypy>=0.560',
+        'pytest>=3.0.3',
+        'responses>=0.5.1',
+    },
+}
+extras_require['all'] = [
+    dep for name, lst in extras_require.items() if name != 'test' for dep in lst
+]
+
 setup_kwargs = dict(
     name='netsuite',
-    version='0.4.1',
-    description='Wrapper around Netsuite SuiteTalk Web Services and Restlets',
+    version='0.5.0',
+    description='Wrapper around Netsuite SuiteTalk SOAP/REST Web Services and Restlets',
     packages=['netsuite'],
     include_package_data=True,
     author='Jacob Magnusson',
@@ -14,20 +36,9 @@ setup_kwargs = dict(
     install_requires=[
         'requests-oauthlib',
         'zeep',
+        'orjson',
     ],
-    extras_require={
-        'cli': [
-            'argh',
-            'ipython',
-        ],
-        'test': {
-            'coverage>=4.2',
-            'flake8>=3.0.4',
-            'mypy>=0.560',
-            'pytest>=3.0.3',
-            'responses>=0.5.1',
-        },
-    },
+    extras_require=extras_require,
     entry_points={
         'console_scripts': [
             'netsuite = netsuite.__main__:main',
@@ -42,6 +53,7 @@ setup_kwargs = dict(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,13 +10,13 @@ envlist = py36, py37, lint
 commands =
     coverage run --source=netsuite -m py.test
 deps =
-    .[cli,test]
+    .[test,all]
 
 [testenv:lint]
 commands =
     flake8 netsuite tests
 deps =
-    .[cli,test]
+    .[test,all]
 
 [flake8]
 ignore =


### PR DESCRIPTION
* Feature: Support for SuiteTalk REST Web Services, including standard GET, POST, PATCH, PUT, DELETE requests as well as making SuiteQL queries. For now it's an optional dependency (install with `pip install netsuite[rest_api]`)
* Feature: Start a HTTP server via command line to browse REST API OpenAPI spec docs for a given set of records (utilizes Swagger UI)
* Breaking change: `--log-level`, `--config-path` and `--config-section` must now be passed directly to the `netsuite` command, and not its sub-commands.